### PR TITLE
RPD-2909 Added plugin with hooks to fix library conflicts

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,6 +13,9 @@
   <keywords>push,notification,push notification,push notifications,apns,gcm,adm,retention,messaging,ios,android,windows phone</keywords>
 
   <license>MIT</license>
+  
+  <!-- dependency required because some plugins conflict on major versions of libraries -->
+  <dependency id="cordova-android-support-gradle-release" url="https://github.com/OutSystems/cordova-android-support-gradle-release.git#1.1.5"/>
 
   <js-module src="www/OneSignal.js" name="OneSignal">
     <clobbers target="OneSignal" />


### PR DESCRIPTION
Adding another [dependency](https://github.com/OutSystems/cordova-android-support-gradle-release.git) is not good. However, considering:
- the ammount of plugins that can conflict with OneSignal
- the complexity of rebuilding the AndroidSDK
- the low impact of this addition (only has hooks to "pin" a gradle version)

It seems the best solution for now. [RPD-2909](https://outsystemsrd.atlassian.net/browse/RPD-2909)