### PR TITLE
RNMT-2651 Change OneSignal hook to copy resources to drawable folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Additions
+- Updates prepare_drawables hook to compute resource paths based on cordova engine from project [RNMT-2651](https://outsystemsrd.atlassian.net/browse/RNMT-2651)
+
+## [2.4.5-OS]
+- Merged upstream (2.4.5) into OutSystems branch
+
+[Unreleased]: https://github.com/OutSystems/OneSignal-Cordova-SDK/compare/2.4.5-OS...HEAD
+[2.4.5-OS]: https://github.com/OutSystems/OneSignal-Cordova-SDK/compare/2.3.2-OS2...2.4.5-OS

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,9 +14,6 @@
   
   <license>MIT</license>
   
-  <!-- dependency required because some plugins conflict on major versions of libraries -->
-  <dependency id="cordova-android-support-gradle-release" url="https://github.com/OutSystems/cordova-android-support-gradle-release.git#1.1.6-OS"/>
-
   <js-module src="www/OneSignal.js" name="OneSignal">
     <clobbers target="OneSignal" />
   </js-module>

--- a/src/android/hooks/prepare_drawables.js
+++ b/src/android/hooks/prepare_drawables.js
@@ -49,7 +49,7 @@ module.exports = function (ctx) {
   }
 
   // Matches first digit (eg. ^8.0.0 returns 8) 
-  var engineMajor = engines[0].spec.match(/\d+[^.]/)[0];
+  var engineMajor = engines[0].spec.match(/(\d+)/)[0];
 
   // If hook is running on project with cordova-android higher or equal than 8, redefine global variables
   if(Number(engineMajor) >= 8){

--- a/src/android/hooks/prepare_drawables.js
+++ b/src/android/hooks/prepare_drawables.js
@@ -1,4 +1,5 @@
-var ICON_FILENAME = 'icon.png';
+var ICON_FILENAME = 'ic_launcher.png';
+var RES_PATH = 'platforms/android/res/';
 
 var map_folders = [
   {
@@ -37,16 +38,36 @@ module.exports = function (ctx) {
 
   var fs = ctx.requireCordovaModule('fs');
   var path = ctx.requireCordovaModule('path');
+  var ConfigParser = ctx.requireCordovaModule('cordova-common').ConfigParser;
 
-  var res_dir = path.join(ctx.opts.projectRoot + '/platforms/android/res/')
+  var appConfig = new ConfigParser(path.join(ctx.opts.projectRoot, "config.xml"));
+
+  var engines = appConfig.getEngines();
+
+  if(engines.length < 0){
+    return;
+  }
+
+  // Matches first digit (eg. ^8.0.0 returns 8) 
+  var engineMajor = engines[0].spec.match(/\d/)[0];
+
+  // If hook is running on project with cordova-android higher or equal than 8, redefine global variables
+  if(Number(engineMajor) >= 8){
+    ICON_FILENAME = 'ic_launcher.png';
+    RES_PATH = 'platforms/android/app/src/main/res/';
+  }
 
   map_folders.forEach(function(folder) {
-    var drawable_folder = path.join(res_dir, folder.dst);
+    var drawable_folder = path.join(ctx.opts.projectRoot, RES_PATH, folder.dst);
 
-    if (!fs.existsSync(drawable_folder))
+    if (!fs.existsSync(drawable_folder)){
       fs.mkdirSync(drawable_folder);
-    else
+    }
+    else{
       console.log("Folder " + folder.dst + " already exists");
+    }
+
+    var res_dir = path.join(ctx.opts.projectRoot, RES_PATH);
 
     var src = path.join(res_dir, folder.src, ICON_FILENAME);
     var dst = path.join(res_dir, folder.dst, ICON_FILENAME);

--- a/src/android/hooks/prepare_drawables.js
+++ b/src/android/hooks/prepare_drawables.js
@@ -44,12 +44,12 @@ module.exports = function (ctx) {
 
   var engines = appConfig.getEngines();
 
-  if(engines.length < 0){
+  if(engines.length <= 0){
     return;
   }
 
   // Matches first digit (eg. ^8.0.0 returns 8) 
-  var engineMajor = engines[0].spec.match(/\d/)[0];
+  var engineMajor = engines[0].spec.match(/\d+[^.]/)[0];
 
   // If hook is running on project with cordova-android higher or equal than 8, redefine global variables
   if(Number(engineMajor) >= 8){

--- a/src/android/hooks/prepare_drawables.js
+++ b/src/android/hooks/prepare_drawables.js
@@ -1,4 +1,4 @@
-var ICON_FILENAME = 'ic_launcher.png';
+var ICON_FILENAME = 'icon.png';
 var RES_PATH = 'platforms/android/res/';
 
 var map_folders = [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Since cordova-android 8.0 changes the internal project structure, the paths inside the hook running in OneSignal plugin needs to be updated to match these changes. Also, the icon resources were renamed as well.

This hook is responsible for copying the icon resources from `mipmap` to `drawable` folders to be able to render the app icon in push notifications.

Also, `cordova-android-support-gradle-release` is removed since is no longer necessary and was causing an error while compiling an app using target-sdk 28.

Fixes https://outsystemsrd.atlassian.net/browse/RNMT-2739
Closes https://outsystemsrd.atlassian.net/browse/RNMT-2651

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [ ] iOS platform
- [x] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Exploratory tests were perfomed. Also, Go tests will be updated to run the previous version of the plugin using MABS 3 and 4 and the new version using MABS 5.0

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->
N/A

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly