### PR TITLE
RNMT-3264 OneSignal ::: Improve compatibility between OneSignal and plugins that depend on Google Services

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -15,7 +15,8 @@ repositories {
 def versionGroupAligns = [
     // ### Google Play Services library
     'com.google.android.gms': [
-        'version': '11.8.+'
+        'version': '11.8.+',
+        'omitModules': ['strict-version-matcher-plugin']
     ],
 
     // ### Google Firebase library


### PR DESCRIPTION
## Description
This commit fixes the issue by adding the plugin to a list of plugins where the version override logic is not applied to.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-3264

<!--- Why is this change required? What problem does it solve? -->
<!--- Describe your changes in detail -->
The build of a mobile app with both the OneSignal and Firebase Mobile plugins fails. The OneSignal
gradle script changes the version of all ‘com.google.android.gms’ dependencies to ‘11.8+’, including a Firebase Mobile dependency (['strict-version-matcher-plugin']) that doesn’t have the ‘11.8+’ version.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)
- [ ] Test (non-breaking change that only affects test code)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Built the OneSignal Sample App with and without the Firebase Plugin with multiple versions of MABS and did a smoke test on each.

Additionally checked that the dependencies were resolved correctly:
<img width="531" alt="Screenshot 2019-09-06 at 22 52 58" src="https://user-images.githubusercontent.com/45076576/64462712-4421a300-d0f9-11e9-9500-22c1a41c082d.png">

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly