### PR TITLE
RNMT-3314 Update OneSignal-Android-SDK

### DIFF
--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -66,5 +66,5 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation 'com.github.OutSystems:OneSignal-Android-SDK:3.10.3-OS2'
+    implementation 'com.github.OutSystems:OneSignal-Android-SDK:3.11.4-OS'
 }


### PR DESCRIPTION
The Cordova SDK was previously merged from upstream but the Android SDK was not updated. This breaks Android builds that use the plugin. 

This PR aims to fix it by updating the OneSignal-Android-SDK dependency.

References https://outsystemsrd.atlassian.net/browse/RNMT-3314