### PR TITLE
RNMT-3623 blocking action init

### DIFF
--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -80,7 +80,8 @@ public class OneSignalPush extends CordovaPlugin {
   
   private static final String ADD_PERMISSION_OBSERVER = "addPermissionObserver";
   private static final String ADD_SUBSCRIPTION_OBSERVER = "addSubscriptionObserver";
-  
+  private static final String REMOVE_SUBSCRIPTION_OBSERVER = "removeSubscriptionObserver";
+
   private static final String GET_TAGS = "getTags";
   private static final String DELETE_TAGS = "deleteTags";
   private static final String SEND_TAGS = "sendTags";
@@ -238,6 +239,12 @@ public class OneSignalPush extends CordovaPlugin {
           }
         };
         OneSignal.addSubscriptionObserver(subscriptionObserver);
+      }
+      result = true;
+    }
+    else if (REMOVE_SUBSCRIPTION_OBSERVER.equals(action)) {
+      if (subscriptionObserver != null) {
+        OneSignal.removeSubscriptionObserver(subscriptionObserver);
       }
       result = true;
     }

--- a/src/ios/OneSignalPush.h
+++ b/src/ios/OneSignalPush.h
@@ -43,6 +43,7 @@
 
 - (void)addPermissionObserver:(CDVInvokedUrlCommand*)command;
 - (void)addSubscriptionObserver:(CDVInvokedUrlCommand*)command;
+- (void)removeSubscriptionObserver:(CDVInvokedUrlCommand*)command;
 - (void)addEmailSubscriptionObserver:(CDVInvokedUrlCommand *)command;
 
 - (void)getTags:(CDVInvokedUrlCommand*)command;

--- a/src/ios/OneSignalPush.m
+++ b/src/ios/OneSignalPush.m
@@ -302,6 +302,13 @@ static Class delegateClass = nil;
         [OneSignal addSubscriptionObserver:self];
 }
 
+- (void)removeSubscriptionObserver:(CDVInvokedUrlCommand*)command {
+    if (subscriptionObserverCallbackId != nil){
+        subscriptionObserverCallbackId = nil;
+        [OneSignal removeSubscriptionObserver:self];
+    }
+}
+
 - (void)addEmailSubscriptionObserver:(CDVInvokedUrlCommand *)command {
     bool first = emailSubscriptionCallbackId == nil;
     emailSubscriptionCallbackId = command.callbackId;

--- a/www/OneSignal.js
+++ b/www/OneSignal.js
@@ -132,6 +132,10 @@ OneSignal.prototype.addSubscriptionObserver = function(callback) {
   cordova.exec(subscriptionCallBackProcessor, function(){}, "OneSignalPush", "addSubscriptionObserver", []);
 };
 
+OneSignal.prototype.removeSubscriptionObserver = function(callback) {
+  cordova.exec(function(){}, function(){}, "OneSignalPush", "removeSubscriptionObserver", []);
+};
+
 OneSignal.prototype.addEmailSubscriptionObserver = function(callback) {
     OneSignal._emailSubscriptionObserverList.push(callback);
     var emailSubscriptionCallbackProcessor = function(state) {


### PR DESCRIPTION
In the Register client action from the plugin we are using another plugin action -> GetIds.

This GetIds action hangs without any response when the userID is null. This scenario happens when, for instance, is the first run and the app is either offline or, for some reason, cannot reach the onesignal api (https://onesignal.com/api/v1)

According to https://github.com/OneSignal/OneSignal-Android-SDK/issues/520 the action we are using for this is deprecated.

This PR simply allows for the usage of the removeSubscriptionObserver to be used by the Outsystems pluggin

References: https://outsystemsrd.atlassian.net/browse/RNMT-3623