### PR TITLE
RMET-1674 - Feat ::: Added request for notification permissions required by Android 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0-OS3]
+### Changes
+- New plugin release to include prompt for notifications permissions on Android.
+
 ## [2.11.0-OS2]
 ### Changes
 - New plugin release to include metadata tag for MABS 7.2.0 compatibility

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS2",
+  "version": "2.11.1-OS3",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS2">
+    version="2.11.1-OS3">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -37,6 +37,7 @@
     <!-- PhoneGap Build (PGB) does not have a amazon build target so it include the required manifest entries in all Android builds. -->
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="com.amazon.device.messaging.permission.RECEIVE" />
+      <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
       <permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" android:protectionLevel="signature" />
       <uses-permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" />
     </config-file>

--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -27,46 +27,29 @@
 
 package com.plugin.gcm;
 
-import android.app.Activity;
-import android.content.Context;
-import android.os.Bundle;
 import android.util.Log;
+
+import com.onesignal.OSEmailSubscriptionObserver;
+import com.onesignal.OSInAppMessageAction;
+import com.onesignal.OSNotification;
+import com.onesignal.OSNotificationOpenResult;
+import com.onesignal.OSPermissionObserver;
+import com.onesignal.OSSubscriptionObserver;
+import com.onesignal.OneSignal;
+import com.onesignal.OneSignal.InAppMessageClickHandler;
+import com.onesignal.OneSignal.NotificationOpenedHandler;
+import com.onesignal.OneSignal.NotificationReceivedHandler;
+
 import org.apache.cordova.CallbackContext;
-import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
-import org.apache.cordova.PluginResult;
+import org.apache.cordova.PermissionHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.Iterator;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.HashMap;
-
-import com.onesignal.OneSignal;
-import com.onesignal.OSNotification;
-import com.onesignal.OSNotificationOpenResult;
-import com.onesignal.OSInAppMessageAction;
-import com.onesignal.OneSignal.NotificationOpenedHandler;
-import com.onesignal.OneSignal.NotificationReceivedHandler;
-import com.onesignal.OneSignal.InAppMessageClickHandler;
-import com.onesignal.OneSignal.GetTagsHandler;
-import com.onesignal.OneSignal.IdsAvailableHandler;
-import com.onesignal.OneSignal.PostNotificationResponseHandler;
-import com.onesignal.OneSignal.EmailUpdateHandler;
-import com.onesignal.OneSignal.EmailUpdateError;
-
-import com.onesignal.OSPermissionObserver;
-import com.onesignal.OSEmailSubscriptionObserver;
-import com.onesignal.OSSubscriptionObserver;
-import com.onesignal.OSPermissionStateChanges;
-import com.onesignal.OSSubscriptionStateChanges;
-import com.onesignal.OSEmailSubscriptionStateChanges;
-
 public class OneSignalPush extends CordovaPlugin {
   private static final String TAG = "OneSignalPush";
+  private static final Integer NOTIFICATION_PERMISSIONS_REQUEST_CODE = 1000;
 
   private static final String SET_NOTIFICATION_RECEIVED_HANDLER = "setNotificationReceivedHandler";
   private static final String SET_NOTIFICATION_OPENED_HANDLER = "setNotificationOpenedHandler";
@@ -164,6 +147,13 @@ public class OneSignalPush extends CordovaPlugin {
               appId,
               new CordovaNotificationOpenedHandler(notifOpenedCallbackContext),
               new CordovaNotificationReceivedHandler(notifReceivedCallbackContext)
+      );
+
+
+      PermissionHelper.requestPermission(
+              this,
+              NOTIFICATION_PERMISSIONS_REQUEST_CODE,
+              "android.permission.POST_NOTIFICATIONS"
       );
 
       // data.getJSONObject(2) is for iOS settings.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Since Android 13 requires the prompt for notification permissions, we implemented in the same moment that is already prompting on iOS, in the SDK initialization.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes the issue: https://outsystemsrd.atlassian.net/browse/RMET-1674

<!--- Why is this change required? What problem does it solve? -->
Android 13 support.
 
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
Executed the P0s tests of the test plan
<!--- Include details of your test environment if relevant -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly

