### PR TITLE
RMET-1495 OneSignal Plugin - Fix for notification trampolins on Android 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Change OneSignal-Android-SDK to point to newer version 3.15.5-OS2 [RNMT-1495](https://outsystemsrd.atlassian.net/browse/RNMT-1495)
 
 ## [2.11.0-OS2]
 ### Changes

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -66,7 +66,7 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation 'com.github.Outsystems:OneSignal-Android-SDK:f705aeed5c'
+    implementation 'com.github.Outsystems:OneSignal-Android-SDK:d660fca2'
     implementation 'com.google.android.gms:play-services-location:15.0.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:15.0.0'
     implementation 'com.google.android.gms:play-services-base:15.0.0'

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -66,7 +66,7 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation 'com.github.Outsystems:OneSignal-Android-SDK:d660fca2'
+    implementation 'com.github.OutSystems:OneSignal-Android-SDK:3.15.5-OS2'
     implementation 'com.google.android.gms:play-services-location:15.0.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:15.0.0'
     implementation 'com.google.android.gms:play-services-base:15.0.0'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR updates the dependency to the OneSignal-Android-SDK so that we use its most recent release tag, containing the fix for the notification trampolins on Android 12.


## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1495

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 8 builds and tested on Android 12 Pixel 3 XL device.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
