### PR TITLE
RMET-2824 OneSignal Plugin - Remove android support library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+- Replaces dependencies to android's Support Library with dependencies to AndroidX [RNMT-2824](https://outsystemsrd.atlassian.net/browse/RNMT-2824)
+
 ## [2.11.1-OS6]
 ### Features
 - Replaces dependency to Jitpack with dependency to Azure repo [RNMT-2036](https://outsystemsrd.atlassian.net/browse/RNMT-2124)

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:15.0.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:15.0.0'
     implementation 'com.google.android.gms:play-services-base:15.0.0'
-    implementation 'com.google.android.gms:play-services-basement:15.0.0'
+    implementation 'com.google.android.gms:play-services-basement:18.2.0'
     implementation 'com.google.android.gms:play-services-tasks:15.0.0'
     implementation 'com.google.android.gms:play-services-stats:15.0.0'
     api 'com.google.firebase:firebase-messaging:[10.2.1, 17.3.99]'

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -57,7 +57,7 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS3-test-5@aar")
+    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS3-test-6@aar")
     implementation 'com.google.android.gms:play-services-location:15.0.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:15.0.0'
     implementation 'com.google.android.gms:play-services-base:15.0.0'

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -57,7 +57,7 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS3@aar")
+    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS3-test-5@aar")
     implementation 'com.google.android.gms:play-services-location:15.0.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:15.0.0'
     implementation 'com.google.android.gms:play-services-base:15.0.0'

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -57,13 +57,12 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS3-test-6@aar")
+    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS4@aar")
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.google.android.gms:play-services-base:18.2.0'
     implementation 'com.google.android.gms:play-services-basement:18.2.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.2'
     implementation 'com.google.android.gms:play-services-stats:17.0.3'
-    //api 'com.google.firebase:firebase-messaging:[10.2.1, 17.3.99]'
     api 'com.google.firebase:firebase-messaging:20.2.1'
 }

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -28,17 +28,6 @@ def versionGroupAligns = [
     //    'version': '11.8.+'
     //],
 
-    // ### Android Support Library
-    'com.android.support': [
-        'requiredCompileSdkVersion': 28,
-        'version': '28.0.0',
-        'omitModules': ['multidex', 'multidex-instrumentation'],
-
-        // Can't use 26 of com.android.support when compileSdkVersion 25 is set
-        // The following error will be thrown if there is a mismatch here.
-        // "No resource found that matches the given name: attr 'android:keyboardNavigationCluster'"
-        'versionFallback': '26.1.+'
-    ]
 ]
 
 def resolveVersion(def versionOverride) {

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -58,11 +58,12 @@ configurations.all { resolutionStrategy {
 
 dependencies {
     implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS3-test-6@aar")
-    implementation 'com.google.android.gms:play-services-location:15.0.0'
-    implementation 'com.google.android.gms:play-services-ads-identifier:15.0.0'
-    implementation 'com.google.android.gms:play-services-base:15.0.0'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+    implementation 'com.google.android.gms:play-services-base:18.2.0'
     implementation 'com.google.android.gms:play-services-basement:18.2.0'
-    implementation 'com.google.android.gms:play-services-tasks:15.0.0'
-    implementation 'com.google.android.gms:play-services-stats:15.0.0'
-    api 'com.google.firebase:firebase-messaging:[10.2.1, 17.3.99]'
+    implementation 'com.google.android.gms:play-services-tasks:18.0.2'
+    implementation 'com.google.android.gms:play-services-stats:17.0.3'
+    //api 'com.google.firebase:firebase-messaging:[10.2.1, 17.3.99]'
+    api 'com.google.firebase:firebase-messaging:20.2.1'
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- This PR removes all dependencies to android's Support Library (https://developer.android.com/topic/libraries/support-library).
    - This includes updating the version of [OneSignal-Android-SDK](https://github.com/OutSystems/OneSignal-Android-SDK).
- This PR also updates dependencies for Google services in the Gradle file (`build-extras-onesignal.gradle`).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2824

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
- Tested MABS 10, MABS 9, and MABS 8.1 builds:
    - MABS 10: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=851b680f9737903dffe7c2c174faffc391fba235
    - MABS 9: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=9e1520e2b53827d3632874a237a9e229180784b6
    - MABS 8.1: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=15a9a4c2dd2049a988ad052f264841daa8577213
    
- Tested in Android 14, 13, and 12.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
