### PR TITLE
RMET-2849 ::: Replace "podspec" Inclusion 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changes
+- Chore: iOS | Use `podspec` element instead of it being a `framework` attribute.
 
 ## [2.11.1-OS7]
 ### Features

--- a/plugin.xml
+++ b/plugin.xml
@@ -89,9 +89,17 @@
       <string>production</string>
     </config-file>
 
-    <framework src="OneSignal" type="podspec" spec="2.15.2" />
     <header-file src="src/ios/OneSignalPush.h" />
     <source-file src="src/ios/OneSignalPush.m" />
+
+    <podspec>
+        <config>
+            <source url="https://cdn.cocoapods.org/"/>
+        </config>
+        <pods>
+            <pod name="OneSignal" spec="2.15.2" />
+        </pods>
+    </podspec>
 
   </platform>
 


### PR DESCRIPTION
## Description
Import the `OneSignal` dependency through the `podspec` attribute instead of `framework`. This change is required by MABS 10.

In order to validate the PR, the following MABS builds were generated, one for 9.0 and another for 10.0. The `OneSignal` dependency folder structure should be identical in both versions:
- [MABS 9.0](https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=d473001ced002674c5486a46a3a4afc0f07effaa)
- [MABS 10.0](https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=132c7ec0b3d702d1f44c6023f93ca90f056c08ec)

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2849

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests 
Done manually. The MABS 10.0 build doesn't fail anymore.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
