### PR TITLE
RMET-3276 ::: iOS ::: Add Privacy Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changes
+- iOS | Update SDK to use the latest forked version. This include the Privacy Manifest file (https://outsystemsrd.atlassian.net/browse/RMET-3276).
 
 ## [2.11.1-OS8]
 ### Changes
-- Chore: iOS | Use `podspec` element instead of it being a `framework` attribute.
+- iOS | Use `podspec` element instead of it being a `framework` attribute.
 
 ## [2.11.1-OS7]
 ### Features

--- a/plugin.xml
+++ b/plugin.xml
@@ -96,8 +96,13 @@
         <config>
             <source url="https://cdn.cocoapods.org/"/>
         </config>
-        <pods>
-            <pod name="OneSignal" spec="2.15.2" />
+        <pods use-frameworks="true">
+            <!-- 
+              After releasing the iOS SDK, the following should be used:
+
+              <pod name="OneSignalXCFramework" tag="2.16.7+1.0.0" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
+            -->
+            <pod name="OneSignalXCFramework" branch="development" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" />
         </pods>
     </podspec>
 


### PR DESCRIPTION
## Description
Update the iOS pod to the forked one. This aims to include the Privacy Manifest file.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3276

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## One Signal Sample App Privacy Report
[OneSignal Sample App-PrivacyReport 2024-04-01 15-20-34.pdf](https://github.com/OutSystems/OneSignal-Cordova-SDK/files/14826618/OneSignal.Sample.App-PrivacyReport.2024-04-01.15-20-34.pdf)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows the code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
