### PR TITLE
Prepare release of `2.11.1-OS9`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-### Changes
-- iOS | Update SDK to use the latest forked version. This include the Privacy Manifest file (https://outsystemsrd.atlassian.net/browse/RMET-3276).
+## 2.11.1-OS9
+
+### Features
+
+- Update iOS SDK to version `2.16.7+1.0.0`. This include the Privacy Manifest file (https://outsystemsrd.atlassian.net/browse/RMET-3276).
 
 ## [2.11.1-OS8]
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS8",
+  "version": "2.11.1-OS9",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS8">
+    version="2.11.1-OS9">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -97,12 +97,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <!-- 
-              After releasing the iOS SDK, the following should be used:
-
-              <pod name="OneSignalXCFramework" tag="2.16.7+1.0.0" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
-            -->
-            <pod name="OneSignalXCFramework" branch="development" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" />
+            <pod name="OneSignalXCFramework" tag="2.16.7+1.0.0" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
         </pods>
     </podspec>
 


### PR DESCRIPTION
## Description
- Prepare release of `2.11.1-OS9`.
- Update iOS SDK to version `2.16.7+1.0.0`.
- Clean `CHANGELOG`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3341