### PR TITLE
RMET-2995 OneSignal Plugin - Fix crash in app message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
-## 2.11.1-OS10
+### Fixes
+
+- Android | Add gradle dependency to CardView. (https://outsystemsrd.atlassian.net/browse/RMET-2995).
+
+## [2.11.1-OS10]
 
 ### Fixes
 
 - Update Android SDK to version `3.15.5-OS5`. This fix the issue (https://outsystemsrd.atlassian.net/browse/RPM-4691).
 
-## 2.11.1-OS9
+## [2.11.1-OS9]
 
 ### Features
 

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -65,4 +65,5 @@ dependencies {
     implementation 'com.google.android.gms:play-services-tasks:18.0.2'
     implementation 'com.google.android.gms:play-services-stats:17.0.3'
     api 'com.google.firebase:firebase-messaging:20.2.1'
+    implementation 'androidx.cardview:cardview:1.0.0'
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Adds Gradle dependency to `CardView`, fixing `NoClassDefFoundError` crash in Android.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2995

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=9983e7cfd58d37d24b99dde138818e8d9f8b6526

MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=3152486332bb878f81452c35f7fd219a9225349f

Tested in Android 14 Pixel 7.

## Screenshots (if appropriate)

**In-App Message being properly received in Android device, after fixing the error:**

![image](https://github.com/OutSystems/OneSignal-Cordova-SDK/assets/27646996/9f763623-844a-4a73-885d-ed6f3be4835a)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
