### PR TITLE
RMET-3870 :: add receiver declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1-OS13]
+### Fixes
+- Android | Update `plugin.xml` with `NotificationDismissReceiver` declaration (https://outsystemsrd.atlassian.net/browse/RMET-3870).
+
 ## [2.11.1-OS12]
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS12",
+  "version": "2.11.1-OS13",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS12">
+    version="2.11.1-OS13">
 
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -54,6 +54,7 @@
           <category android:name="$PACKAGE_NAME" />
         </intent-filter>
       </receiver>
+      <receiver android:exported="false" android:name="com.onesignal.NotificationDismissReceiver" />
     </config-file>
 
     <source-file src="src/android/com/plugin/gcm/OneSignalPush.java" target-dir="src/com/plugin/gcm/" />


### PR DESCRIPTION
## Description
The `NotificationDismissReceiver` declaration was missing in the `plugin.xml` , which was causing the receiver to not ever be called and as such, no dismissed notifications were being processed by one signal, causing the resurrections of them all

This PR adds this declaration.

## Context
References: https://outsystemsrd.atlassian.net/browse/RMET-3870

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
MABS 10 build @ https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=f71d19a3a419ed0f9af495fa81b0acbab0c984a3&stg=dev

MABS 11 build @ https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=8050c78b355d256cdd11d7a778224559fd498576&stg=dev

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
