### PR TITLE
RMET-4236 iOS - Deeplink fix for iOS 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1-OS14]
+### Fixes
+- iOS | Fix deeplink handling for iOS 18 (https://outsystemsrd.atlassian.net/browse/RMET-4236).
+
 ## [2.11.1-OS13]
 ### Fixes
 - Android | Update `plugin.xml` with `NotificationDismissReceiver` declaration (https://outsystemsrd.atlassian.net/browse/RMET-3870).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS13",
+  "version": "2.11.1-OS14",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS13">
+    version="2.11.1-OS14">
   
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>
@@ -98,7 +98,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" tag="test/RMET-4328/signed-framework" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
+            <pod name="OneSignalXCFramework" tag="2.16.7+1.0.1" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -98,7 +98,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" tag="fix/RMET-4328/open-url" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
+            <pod name="OneSignalXCFramework" tag="test/RMET-4328/signed-framework" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -98,7 +98,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" tag="test/RMET-4236/OneSignalOpenUrl" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
+            <pod name="OneSignalXCFramework" tag="fix/RMET-4328/open-url" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -98,7 +98,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" tag="2.16.7+1.0.0" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
+            <pod name="OneSignalXCFramework" tag="test/RMET-4236/OneSignalOpenUrl" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
         </pods>
     </podspec>
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR updates the dependency to the iOS library to get the fix from https://github.com/OutSystems/OneSignal-iOS-SDK/pull/5

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-3608

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested on iOS 18 and 17 with MABS 11 and MABS 10 builds.

MABS 11 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=49e9cdd50c5333a2cd2711b4b92850e1aaa31f31&stg=dev

MABS 10 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=dc2bb62603f784b450907017dc504eda1197ba10&stg=dev

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
