### PR TITLE
RMET-3654 - Use hook to add Azure repo for Capacitor apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1-OS15]
+### Fixes
+- android | Add hook to add Azure repo to `build.gradle` (https://outsystemsrd.atlassian.net/browse/RMET-3654).
+
 ## [2.11.1-OS14]
 ### Fixes
 - iOS | Fix deeplink handling for iOS 18 (https://outsystemsrd.atlassian.net/browse/RMET-4236).

--- a/capacitor_hooks/insert_azure_repository.js
+++ b/capacitor_hooks/insert_azure_repository.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+
+const platform = process.env.CAPACITOR_PLATFORM_NAME;
+console.log("\OneSignal plugin - running hook after update - for " + platform);
+const projectDirPath = process.env.CAPACITOR_ROOT_DIR;
+
+if (platform == 'android') {
+    fixAndroidAzureRepository();
+}
+
+/**
+ * Add the azure repository (where OneSignal native Android library is housed) to project root's build.gradle
+ * Because capacitor plugins are injected as separate gradle modules, this is necessary for release builds lintVital gradle tasks to pass.
+ */
+function fixAndroidAzureRepository() {
+    const gradleFilePath = path.resolve(projectDirPath, 'android/build.gradle');
+    const azureUrl = 'https://pkgs.dev.azure.com/OutSystemsRD/9e79bc5b-69b2-4476-9ca5-d67594972a52/_packaging/PublicArtifactRepository/maven/v1';
+    const mavenBlock = `        maven {
+            url "${azureUrl}"
+        }`;
+
+    let gradleContent = fs.readFileSync(gradleFilePath, 'utf8');
+
+    if (gradleContent.includes(azureUrl)) {
+        console.log('\t[SKIPPED] Azure repository already in root build.gradle.');
+    } else {
+        const allprojectsStart = gradleContent.indexOf('allprojects {');
+        if (allprojectsStart === -1) {
+            console.warn('\t[WARNING] Could not find allprojects { ... } block. Unable to add Azure Repository');
+            return;
+        }
+        const repositoriesStart = gradleContent.indexOf('repositories {', allprojectsStart);
+        if (repositoriesStart === -1) {
+            console.warn('\t[WARNING] Could not find allprojects { repositories { ... } } block. Unable to add Azure Repository');
+            return;
+        }
+        // Track braces to find end of repositories block
+        let braceCount = 0;
+        let i = repositoriesStart + 'repositories {'.length - 1;
+        let endIndex = -1;
+        while (i < gradleContent.length) {
+            if (gradleContent[i] === '{') braceCount++;
+            else if (gradleContent[i] === '}') braceCount--;
+
+            if (braceCount === 0) {
+                endIndex = i;
+                break;
+            }
+            i++;
+        }
+        if (endIndex === -1) {
+            console.warn('\t[WARNING] Could not find allprojects { repositories { ... } } block. Unable to add Azure Repository');
+            return;
+        }
+        const closingBraceLineStartIndex = gradleContent.lastIndexOf('\n', endIndex);
+        // Insert the maven block at the end of the repositories block (before closing brace), because gradle searches repositories by order.
+        // The Azure repo should be the last one since it will only apply for a few dependencies.
+        // Otherwise this could slow down gradle build.
+        const updatedContent = gradleContent.slice(0, closingBraceLineStartIndex) + '\n' + mavenBlock + gradleContent.slice(closingBraceLineStartIndex);
+        fs.writeFileSync(gradleFilePath, updatedContent, 'utf8');
+        console.log('\t[SUCCESS] Added Azure repository maven block to the root build.gradle.');
+    }
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   "homepage": "https://github.com/onesignal/OneSignal-Cordova-SDK#readme",
   "scripts": {
     "build": "vite build",
-    "test": "jest --coverage --ci"
+    "test": "jest --coverage --ci",
+    "capacitor:update:after": "node capacitor_hooks/insert_azure_repository.js"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS14",
+  "version": "2.11.1-OS15",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS14">
+    version="2.11.1-OS15">
   
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
       <permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" android:protectionLevel="signature" />
       <uses-permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" />
     </config-file>
-    <config-file target="AndroidManifest.xml" parent="/manifest/application">
+    <edit-config target="AndroidManifest.xml" parent="/manifest/application">
       <amazon:enable-feature android:name="com.amazon.device.messaging" android:required="false" xmlns:amazon="http://schemas.amazon.com/apk/res/android" />
       <service android:name="com.onesignal.ADMMessageHandler" android:exported="true" />
       <receiver
@@ -55,7 +55,7 @@
         </intent-filter>
       </receiver>
       <receiver android:exported="false" android:name="com.onesignal.NotificationDismissReceiver" />
-    </config-file>
+    </edit-config>
 
     <source-file src="src/android/com/plugin/gcm/OneSignalPush.java" target-dir="src/com/plugin/gcm/" />
     <source-file src="src/android/com/plugin/gcm/OneSignalController.java" target-dir="src/com/plugin/gcm/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
       <permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" android:protectionLevel="signature" />
       <uses-permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" />
     </config-file>
-    <edit-config target="AndroidManifest.xml" parent="/manifest/application">
+    <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <amazon:enable-feature android:name="com.amazon.device.messaging" android:required="false" xmlns:amazon="http://schemas.amazon.com/apk/res/android" />
       <service android:name="com.onesignal.ADMMessageHandler" android:exported="true" />
       <receiver
@@ -55,7 +55,7 @@
         </intent-filter>
       </receiver>
       <receiver android:exported="false" android:name="com.onesignal.NotificationDismissReceiver" />
-    </edit-config>
+    </config-file>
 
     <source-file src="src/android/com/plugin/gcm/OneSignalPush.java" target-dir="src/com/plugin/gcm/" />
     <source-file src="src/android/com/plugin/gcm/OneSignalController.java" target-dir="src/com/plugin/gcm/" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds Capacitor hook to add Azure repo for Capacitor apps
- This is necessary when doing Release builds.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-3654

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested MABS 12 Debug and Release builds.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
