### PR TITLE
RMET-4269 - Add hook to set `handleApplicationNotifications` for Capacitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1-OS16]
+### Fixes
+- ios | Add hook to add set `handleApplicationNotifications` (https://outsystemsrd.atlassian.net/browse/RMET-4269).
+
 ## [2.11.1-OS15]
 ### Fixes
 - android | Add hook to add Azure repo to `build.gradle` (https://outsystemsrd.atlassian.net/browse/RMET-3654).

--- a/capacitor_hooks/sethandleApplicationNotifications.js
+++ b/capacitor_hooks/sethandleApplicationNotifications.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const platform = process.env.CAPACITOR_PLATFORM_NAME;
+if (platform != 'ios') {
+    // only needed for iOS - to allow for custom handling of notifications different from what capacitor uses.
+    return;
+}
+const projectDirPath = process.env.CAPACITOR_ROOT_DIR;
+const configPath = path.resolve(projectDirPath, 'ios', 'App', 'App', 'capacitor.config.json');
+console.log('\OneSignal plugin - running hook before copy for iOS.')
+
+// read the existing config json
+let config = {};
+try {
+  const fileContent = fs.readFileSync(configPath, 'utf-8');
+  config = JSON.parse(fileContent);
+} catch (e) {
+  console.error('\t[ERROR] - Invalid JSON reading and parse - ' + e);
+  process.exit(1);
+}
+
+// merge the new content with the existing json
+const newConfig = {
+  ios: {
+    handleApplicationNotifications: false
+  }
+};
+config.ios = {
+  ...config.ios,
+  ...newConfig.ios
+};
+
+// Write back to config.json
+fs.writeFileSync(configPath, JSON.stringify(config, null, 4));
+console.log('\t[SUCCESS] capacitor.config.json updated successfully.');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS15",
+  "version": "2.11.1-OS16",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "build": "vite build",
     "test": "jest --coverage --ci",
-    "capacitor:update:after": "node capacitor_hooks/insert_azure_repository.js"
+    "capacitor:update:after": "node capacitor_hooks/insert_azure_repository.js; node capacitor_hooks/sethandleApplicationNotifications.js"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS15">
+    version="2.11.1-OS16">
   
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds Capacitor hook to set `handleApplicationNotifications` to false for Capacitor apps, which allows push notifications to be handled by OneSignal when the app is open.
- More info in here: https://documentation.onesignal.com/docs/ionic-capacitor-cordova-sdk-setup#instructions-for-ionic--capacitor 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-4269

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested MABS 12 builds.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
