### PR TITLE
fix(android): OutSystems Capacitor Android builds by changing `manifestPlaceholders` declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1-OS17]
+### Fixes
+- android | Override of `manifestPlaceholders` breaking OutSystems Capacitor builds (https://outsystemsrd.atlassian.net/browse/RMET-4863).
+
 ## [2.11.1-OS16]
 ### Fixes
 - ios | Add hook to add set `handleApplicationNotifications` (https://outsystemsrd.atlassian.net/browse/RMET-4269).

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -1,5 +1,7 @@
-android.defaultConfig.manifestPlaceholders.onesignal_app_id = '', // Use from js code
-android.defaultConfig.manifestPlaceholders.onesignal_google_project_number = 'REMOTE'
+android.defaultConfig {
+  manifestPlaceholders.onesignal_app_id = ''
+  manifestPlaceholders.onesignal_google_project_number = 'REMOTE'
+}
 
 repositories {
     maven { url 'https://maven.google.com' }

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -1,8 +1,6 @@
 android.defaultConfig {
-  manifestPlaceholders = [
-    onesignal_app_id: '', // Use from js code
-    onesignal_google_project_number: 'REMOTE'
-  ]
+  manifestPlaceholders.onesignal_app_id = '', // Use from js code
+  manifestPlaceholders.onesignal_google_project_number = 'REMOTE'
 }
 
 repositories {

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -57,7 +57,7 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS5@aar")
+    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS6@aar")
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.google.android.gms:play-services-base:18.2.0'

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -1,6 +1,8 @@
-android.defaultConfig {
-  manifestPlaceholders.onesignal_app_id = '', // Use from js code
-  manifestPlaceholders.onesignal_google_project_number = 'REMOTE'
+android {
+    defaultConfig {
+        manifestPlaceholders.onesignal_app_id = '', // Use from js code
+        manifestPlaceholders.onesignal_google_project_number = 'REMOTE'
+    }
 }
 
 repositories {

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -1,9 +1,5 @@
-android {
-    defaultConfig {
-        manifestPlaceholders.onesignal_app_id = '', // Use from js code
-        manifestPlaceholders.onesignal_google_project_number = 'REMOTE'
-    }
-}
+android.defaultConfig.manifestPlaceholders.onesignal_app_id = '', // Use from js code
+android.defaultConfig.manifestPlaceholders.onesignal_google_project_number = 'REMOTE'
 
 repositories {
     maven { url 'https://maven.google.com' }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS16",
+  "version": "2.11.1-OS17",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS16">
+    version="2.11.1-OS17">
   
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>


### PR DESCRIPTION
## Description

Change how `manifestPlaceholders` are declared, which was overriding an OutSystems Capacitor application's own `manifestPlaceholders`, which would cause compilation to fail.

Also includes [update to Android SDK](https://github.com/OutSystems/OneSignal-Android-SDK/pull/22), which removes its own `manifestPlaceholders`.

In truth we may not need these placeholders to begin with, and they don't exist in the most recent version of upstream, but this was a simpler solution rather than removing them altogether and checking for impact.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4863 

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Using One Signal App - https://eng-mobile.outsystems.dev/apps/application?id=42b463b2-dcd9-4006-8f20-da760b68d10a&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b&tab=mobiledistribution&mobileoption=android - MABS 12 Capacitor builds pass and push notifications (including with deeplinks) still work. Also checked with other MABS versions and everything is still working.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
