### PR TITLE
fix: Crash when tapping on Notification action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1-OS18]
+### Fixes
+- android | Fix crash when clicking on notification action (https://outsystemsrd.atlassian.net/browse/RMET-3566).
+
 ## [2.11.1-OS17]
 ### Fixes
 - android | Override of `manifestPlaceholders` breaking OutSystems Capacitor builds (https://outsystemsrd.atlassian.net/browse/RMET-4863).

--- a/build-extras-onesignal.gradle
+++ b/build-extras-onesignal.gradle
@@ -55,7 +55,7 @@ configurations.all { resolutionStrategy {
 }}
 
 dependencies {
-    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS6@aar")
+    implementation("com.github.outsystems:onesignal-android-sdk:3.15.5-OS7@aar")
     implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.google.android.gms:play-services-base:18.2.0'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS17",
+  "version": "2.11.1-OS18",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS17">
+    version="2.11.1-OS18">
   
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>


### PR DESCRIPTION
Fix brought from Android SDK -> https://github.com/OutSystems/OneSignal-Android-SDK/pull/23

Context: https://outsystemsrd.atlassian.net/browse/RMET-3566

### Testing

If you'd like to test, you'll need access to OneSignal Dashboard. PM me if you'd like to test (but you don't have to if you don't want to). You can use the O11 OneSignal Sample app where the crash is fixed, and if you want you can compare with ODC (where the branch wasn't updated to this PR so the crash still occurs). 