### PR TITLE
feat: Support for SPM 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 package-lock.json
 coverage
+.build/
+Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 package-lock.json
 coverage
 .build/
+.swiftpm/
 Package.resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1-OS19]
+### Features
+- ios | Support Swift Package Manager (https://outsystemsrd.atlassian.net/browse/RMET-5135).
+
 ## [2.11.1-OS18]
 ### Fixes
 - android | Fix crash when clicking on notification action (https://outsystemsrd.atlassian.net/browse/RMET-3566).

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,9 @@ let package = Package(
                 .product(name: "OneSignal", package: "OneSignal-iOS-SDK")
             ],
             path: "src/ios",
-            publicHeadersPath: ".")
+            publicHeadersPath: ".",
+            linkerSettings: [
+                .linkedFramework("SystemConfiguration")
+            ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,6 @@ let package = Package(
                 .product(name: "OneSignal", package: "OneSignal-iOS-SDK")
             ],
             path: "src/ios",
-            publicHeadersPath: ".",
-            linkerSettings: [
-                .linkedFramework("SystemConfiguration")
-            ])
+            publicHeadersPath: ".")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "onesignal-cordova-plugin",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "onesignal-cordova-plugin",
+            targets: ["OneSignalPushPlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
+        .package(
+            url: "https://github.com/OutSystems/OneSignal-iOS-SDK.git",
+            exact: "2.16.7-test.2")
+    ],
+    targets: [
+        .target(
+            name: "OneSignalPushPlugin",
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios"),
+                .product(name: "OneSignal", package: "OneSignal-iOS-SDK")
+            ],
+            path: "src/ios",
+            publicHeadersPath: ".")
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
         .package(
             url: "https://github.com/OutSystems/OneSignal-iOS-SDK.git",
-            exact: "2.16.7-test.2")
+            exact: "2.16.7-outsystems.1")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     products: [
         .library(
             name: "onesignal-cordova-plugin",
-            targets: ["OneSignalPushPlugin"])
+            targets: ["onesignal-cordova-plugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "OneSignalPushPlugin",
+            name: "onesignal-cordova-plugin",
             dependencies: [
                 .product(name: "Cordova", package: "cordova-ios"),
                 .product(name: "OneSignal", package: "OneSignal-iOS-SDK")

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ For account issues and support please contact OneSignal support from the [OneSig
 To make things easier, we have published demo projects for [Cordova](https://github.com/OneSignal/OneSignal-Cordova-Example) and [Ionic](https://github.com/OneSignal/OneSignal-Ionic-Example)
 
 #### Supports:
-* Cordova, Ionic, Ionic Capacitor, and Phonegap
-* Android 4.0.3 (API Level 15) through 10 (API Level 29), and Amazon FireOS
-* iOS 7 - 13
+* OutSystems O11 / ODC with Capacitor and Cordova.
+* Android 9 (API Level 28) through 16 (API Level 36).
+* iOS 15 - 26

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ For account issues and support please contact OneSignal support from the [OneSig
 #### Demo Project
 To make things easier, we have published demo projects for [Cordova](https://github.com/OneSignal/OneSignal-Cordova-Example) and [Ionic](https://github.com/OneSignal/OneSignal-Ionic-Example)
 
-#### Supports:
+#### Supports
+
+This fork supports:
+
 * OutSystems O11 / ODC with Capacitor and Cordova.
 * Android 9 (API Level 28) through 16 (API Level 36).
 * iOS 15 - 26

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.1-OS18",
+  "version": "2.11.1-OS19",
   "name": "onesignal-cordova-plugin",
   "cordova_name": "OneSignal Push Notifications",
   "description": "OneSignal is a high volume Push Notification service for mobile apps. In addition to basic notification delivery, OneSignal also provides tools to localize, target, schedule, and automate notifications that you send.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -98,7 +98,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" tag="2.16.7+1.0.1" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" nospm="true" />
+            <pod name="OneSignalXCFramework" tag="2.16.7-test.2" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" nospm="true" />
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -75,8 +75,6 @@
         </feature>
     </config-file>
 
-    <framework src="SystemConfiguration.framework" />
-
     <config-file target="*-Info.plist" parent="UIBackgroundModes">
       <array>
         <string>remote-notification</string>

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,7 +67,7 @@
   </platform>
 
   <!-- ios -->
-  <platform name="ios">
+  <platform name="ios" package="swift">
 
     <config-file target="config.xml" parent="/*">
       <feature name="OneSignalPush">
@@ -98,7 +98,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" tag="2.16.7+1.0.1" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" /> 
+            <pod name="OneSignalXCFramework" tag="2.16.7+1.0.1" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" nospm="true" />
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -98,7 +98,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="OneSignalXCFramework" tag="2.16.7-test.2" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" nospm="true" />
+            <pod name="OneSignalXCFramework" tag="2.16.7-outsystems.1" git="https://github.com/OutSystems/OneSignal-iOS-SDK.git" nospm="true" />
         </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="onesignal-cordova-plugin"
-    version="2.11.1-OS18">
+    version="2.11.1-OS19">
   
   <name>OneSignal Push Notifications</name>
   <author>Josh Kasten, Bradley Hesse, Rodrigo Gomez-Palacio</author>


### PR DESCRIPTION
## ⚠️ AI-assisted PR with Claude Code / Koda

This PR adds support for SPM by:

- Adding a Package.swift file with the required dependencies for SPM support - [cordova-ios as described in plugin guide](https://cordova.apache.org/docs/en/latest/guide/platforms/ios/plugin.html#supporting-swift-package-manager-spm), and OneSignal iOS SDK via https://github.com/OutSystems/OneSignal-iOS-SDK/pull/8
- Update `plugin.xml` to support SPM and not add pod dependency.


### Testing

- ✅ I've tested a Cordova iOS 8 app (which supports SPM), and everything works fine - App accessible at https://github.com/ionic-team/cordova-plugins-ios-spm-test-apps/tree/main/onesignal_cordova_ios8 (see readme for information on the app)
- ✅ I've tested a Capacitor SPM app with Capacitor CLI version that supports `Package.swift`  - https://github.com/ionic-team/cordova-plugins-ios-spm-test-apps/tree/main/onesignal_capacitor_spm
- ✅ Also checked backwards compatibility with CocoaPods on both Cordova and Capacitor and everything still works - More info at https://github.com/ionic-team/cordova-plugins-ios-spm-test-apps#onesignal

### References: 
- https://outsystemsrd.atlassian.net/browse/RMET-5135
- Implementation plan generated and followed by Koda, with tweaks from me: For reference: [plan.md](https://github.com/user-attachments/files/26929983/plan.md)
